### PR TITLE
Ensure dockerfiles are built in the right order and slightly improve local usability

### DIFF
--- a/build_images.py
+++ b/build_images.py
@@ -3,26 +3,47 @@ import os
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from pathlib import Path
-from typing import List
+from subprocess import CompletedProcess
+from typing import Generator, List
 
 TARGET_REGISTRY = "ghcr.io/coveooss/tgf"
 
 
-def _run_command(command: List[str]) -> None:
+def _run_command(command: List[str], capture_output: bool = False) -> CompletedProcess:
     print(" ".join(command))
-    subprocess.check_call(command)
+    return subprocess.run(command, check=True, capture_output=capture_output)
+
+
+@contextmanager
+def docker_buildx_builder() -> Generator[str, None, None]:
+    print("Creating a docker buildx builder")
+
+    process = _run_command(["docker", "buildx", "create"], capture_output=True)
+    builder_name = process.stdout.decode("utf-8").strip()
+
+    print(f"Created docker buildx builder named {builder_name}")
+
+    try:
+        yield builder_name
+    finally:
+        print(f"Removing docker buildx builder named {builder_name}")
+        _run_command(["docker", "buildx", "rm", builder_name])
 
 
 def build_and_push_dockerfile(
-    dockerfile: Path, git_tag: str, push: bool = False, beta: bool = False
+    builder: str,
+    dockerfile: Path,
+    git_tag: str,
+    push: bool = False,
+    beta: bool = False,
 ) -> None:
     name = dockerfile.name
     print(f"\n----------------------------------------\nProcessing file {name}")
 
     tag = (re.match("Dockerfile\.\d+(\.(.+))?", name).group(2) or "").lower()
     tag_suffix = f"-{tag}" if tag else ""
-    display_name = tag or "base"
 
     version = git_tag.lstrip("v")
     version_maj_min = ".".join(version.split(".")[:2])
@@ -41,8 +62,7 @@ def build_and_push_dockerfile(
     temp_dockerfile = Path("dockerfile.temp")
     temp_dockerfile.open(mode="w", encoding="utf-8").write(dockerfile_content)
 
-    print(f"== Building {display_name} ==")
-    _run_command(["docker", "buildx", "create", "--use"])
+    print(f"== Building {target_tag} from {dockerfile.relative_to(Path.cwd())} ==")
     if not push:
         print(f"Not pushing, call with --push to do so")
     build_command = (
@@ -50,6 +70,8 @@ def build_and_push_dockerfile(
             "docker",
             "buildx",
             "build",
+            "--builder",
+            builder,
             "-f",
             temp_dockerfile.name,
             "-t",
@@ -79,11 +101,20 @@ def main(push: bool = False, beta: bool = False) -> None:
         print('Tag does not start with "v", ignoring')
         sys.exit(0)
 
-    for dockerfile in Path.cwd().glob("Dockerfile*"):
-        if not dockerfile.is_file():
-            continue
+    dockerfiles = [
+        dockerfile
+        for dockerfile in Path.cwd().glob("Dockerfile*")
+        if dockerfile.is_file()
+    ]
+    dockerfiles = sorted(dockerfiles)
 
-        build_and_push_dockerfile(dockerfile, git_tag, push, beta)
+    print("Will build the following dockerfiles in order:")
+    for dockerfile in dockerfiles:
+        print(f"- {dockerfile.relative_to(Path.cwd())}")
+
+    with docker_buildx_builder() as builder:
+        for dockerfile in dockerfiles:
+            build_and_push_dockerfile(builder, dockerfile, git_tag, push, beta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are two main things that are done in this PR.

The first is to make sure that the Dockerfiles are built in the right order. For some reason, the order of files returned in [this](https://github.com/coveooss/tgf-images/runs/4518900503?check_suite_focus=true) build run is not in the right order. It starts with `Dockerfile.1` for some reason. This PR makes it that the files are all sorted before being run. This should resolve this issue.

The second thing this PR does is to try to improve the experience when running this locally. There's a few fixes and attempted fixes in there:

1. We clean up the `docker buildx` builders that we create when we're done with them. Previously they were left around and would accumulate.
2. We extract the platforms list as a CLI argument. This allows users to only build one version locally if they'd like.