### PR TITLE
Fix terraform-docs not being an actual executable in built image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
         run: docker run --privileged --rm tonistiigi/binfmt --install all
 
       - name: Build and push PR images for testing
-        if: ${{ github.event_name == "pull_request" }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
         run: python ./build_and_push_images.py --version "v0.0.PR-$PR_NUMBER"
 
       - name: Build and push release images
-        if: ${{ github.event_name == "tag" }}
+        if: ${{ github.event_name == 'tag' }}
         env:
           VERSION: ${{ github.ref_name }}
         run: python ./build_and_push_images.py --version "$VERSION"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  pull_request: {}
   push:
     tags:
       - "v*"
@@ -9,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -27,5 +28,14 @@ jobs:
       - name: Prepare Docker build
         run: docker run --privileged --rm tonistiigi/binfmt --install all
 
-      - name: Build and Push Images
-        run: python ./build_images.py --push
+      - name: Build and push PR images for testing
+        if: ${{ github.event_name == "pull_request" }}
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: python ./build_and_push_images.py --version "v0.0.PR-$PR_NUMBER"
+
+      - name: Build and push release images
+        if: ${{ github.event_name == "tag" }}
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: python ./build_and_push_images.py --version "$VERSION"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Build and push PR images for testing
         if: ${{ github.event_name == 'pull_request' }}
         env:
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.number }}
         run: python ./build_and_push_images.py --version "v0.0.PR-$PR_NUMBER"
 
       - name: Build and push release images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on: pull_request
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    container: koalaman/shellcheck-alpine:stable
+
+    steps:
+      - name: Install system dependencies
+        run: |
+          apk add --no-cache \
+            git \
+            fd
+
+      - uses: actions/checkout@v2
+
+      - name: Run shellcheck
+        run: fd --hidden --exclude .git . -e .sh -x shellcheck --color=always

--- a/Dockerfile.0_scripts/download_executables.sh
+++ b/Dockerfile.0_scripts/download_executables.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -xeu
 
 if [ "$TARGETPLATFORM" = linux/arm64 ]
 then

--- a/Dockerfile.0_scripts/download_executables.sh
+++ b/Dockerfile.0_scripts/download_executables.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -xeu
 
+download_and_install() {
+  url="$1"
+  dest="$2"
+
+  curl --silent --show-error --fail --location -o out.zip "$url"
+  unzip -p out.zip "$dest"
+  chmod +x "$dest"
+  rm -rf out.zip
+}
+
 if [ "$TARGETPLATFORM" = linux/arm64 ]; then
   TF_PLATFORM=linux_arm64
   EXT=linux_arm64
@@ -9,24 +19,14 @@ else
   EXT=linux_64-bits
 fi
 
-
 TERRAFORM_PATH=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TF_PLATFORM}.zip
 echo "Downloading terraform from $TERRAFORM_PATH"
-curl -sLo_ "${TERRAFORM_PATH}"
-unzip -p _ > "${EXE_FOLDER}/terraform"
-chmod +x "${EXE_FOLDER}/terraform"
-rm -f _
+download_and_install "$TERRAFORM_PATH" "$EXE_FOLDER/terraform"
 
 TERRAGRUNT_PATH=https://github.com/coveo/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_${TERRAGRUNT_VERSION}_${EXT}.zip
 echo "Downloading terragrunt from $TERRAGRUNT_PATH"
-curl -sLo_ "${TERRAGRUNT_PATH}"
-unzip -p _ > "${EXE_FOLDER}/terragrunt"
-chmod +x "${EXE_FOLDER}/terragrunt"
-rm -f _
+download_and_install "$TERRAGRUNT_PATH" "$EXE_FOLDER/terragrunt"
 
 GOTEMPLATE_PATH=https://github.com/coveo/gotemplate/releases/download/v${GOTEMPLATE_VERSION}/gotemplate_${GOTEMPLATE_VERSION}_${EXT}.zip
 echo "Downloading gotemplate from $GOTEMPLATE_PATH"
-curl -sLo_ "${GOTEMPLATE_PATH}"
-unzip -p _ > "${EXE_FOLDER}/gotemplate"
-chmod +x "${EXE_FOLDER}/gotemplate"
-rm -f _
+download_and_install "$GOTEMPLATE_PATH" "$EXE_FOLDER/gotemplate"

--- a/Dockerfile.0_scripts/download_executables.sh
+++ b/Dockerfile.0_scripts/download_executables.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
-
 set -xeu
 
-if [ "$TARGETPLATFORM" = linux/arm64 ]
-then
+if [ "$TARGETPLATFORM" = linux/arm64 ]; then
   TF_PLATFORM=linux_arm64
   EXT=linux_arm64
 else
@@ -15,20 +13,20 @@ fi
 TERRAFORM_PATH=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TF_PLATFORM}.zip
 echo "Downloading terraform from $TERRAFORM_PATH"
 curl -sLo_ "${TERRAFORM_PATH}"
-unzip -p _ > "${EXE_FOLDER}"/terraform
-chmod +x "${EXE_FOLDER}"/terraform
+unzip -p _ > "${EXE_FOLDER}/terraform"
+chmod +x "${EXE_FOLDER}/terraform"
 rm -f _
 
 TERRAGRUNT_PATH=https://github.com/coveo/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_${TERRAGRUNT_VERSION}_${EXT}.zip
 echo "Downloading terragrunt from $TERRAGRUNT_PATH"
 curl -sLo_ "${TERRAGRUNT_PATH}"
-unzip -p _ > "${EXE_FOLDER}"/terragrunt
-chmod +x "${EXE_FOLDER}"/terragrunt
+unzip -p _ > "${EXE_FOLDER}/terragrunt"
+chmod +x "${EXE_FOLDER}/terragrunt"
 rm -f _
 
 GOTEMPLATE_PATH=https://github.com/coveo/gotemplate/releases/download/v${GOTEMPLATE_VERSION}/gotemplate_${GOTEMPLATE_VERSION}_${EXT}.zip
 echo "Downloading gotemplate from $GOTEMPLATE_PATH"
 curl -sLo_ "${GOTEMPLATE_PATH}"
-unzip -p _ > "${EXE_FOLDER}"/gotemplate
-chmod +x "${EXE_FOLDER}"/gotemplate
+unzip -p _ > "${EXE_FOLDER}/gotemplate"
+chmod +x "${EXE_FOLDER}/gotemplate"
 rm -f _

--- a/Dockerfile.0_scripts/download_executables.sh
+++ b/Dockerfile.0_scripts/download_executables.sh
@@ -6,7 +6,7 @@ download_and_install() {
   dest="$2"
 
   curl --silent --show-error --fail --location -o out.zip "$url"
-  unzip -p out.zip "$dest"
+  unzip -p out.zip > "$dest"
   chmod +x "$dest"
   rm -rf out.zip
 }

--- a/Dockerfile.0_scripts/download_executables.sh
+++ b/Dockerfile.0_scripts/download_executables.sh
@@ -14,21 +14,21 @@ fi
 
 TERRAFORM_PATH=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TF_PLATFORM}.zip
 echo "Downloading terraform from $TERRAFORM_PATH"
-curl -sLo_ ${TERRAFORM_PATH}
-unzip -p _ > ${EXE_FOLDER}/terraform
-chmod +x ${EXE_FOLDER}/terraform
+curl -sLo_ "${TERRAFORM_PATH}"
+unzip -p _ > "${EXE_FOLDER}"/terraform
+chmod +x "${EXE_FOLDER}"/terraform
 rm -f _
 
 TERRAGRUNT_PATH=https://github.com/coveo/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_${TERRAGRUNT_VERSION}_${EXT}.zip
 echo "Downloading terragrunt from $TERRAGRUNT_PATH"
-curl -sLo_ ${TERRAGRUNT_PATH}
-unzip -p _ > ${EXE_FOLDER}/terragrunt
-chmod +x ${EXE_FOLDER}/terragrunt
+curl -sLo_ "${TERRAGRUNT_PATH}"
+unzip -p _ > "${EXE_FOLDER}"/terragrunt
+chmod +x "${EXE_FOLDER}"/terragrunt
 rm -f _
 
 GOTEMPLATE_PATH=https://github.com/coveo/gotemplate/releases/download/v${GOTEMPLATE_VERSION}/gotemplate_${GOTEMPLATE_VERSION}_${EXT}.zip
 echo "Downloading gotemplate from $GOTEMPLATE_PATH"
-curl -sLo_ ${GOTEMPLATE_PATH}
-unzip -p _ > ${EXE_FOLDER}/gotemplate
-chmod +x ${EXE_FOLDER}/gotemplate
+curl -sLo_ "${GOTEMPLATE_PATH}"
+unzip -p _ > "${EXE_FOLDER}"/gotemplate
+chmod +x "${EXE_FOLDER}"/gotemplate
 rm -f _

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -11,12 +11,12 @@ fi
 
 TFLINT_PATH=https://github.com/terraform-linters/tflint/releases/download/v${TF_LINT_VERSION}/tflint_linux_${PLATFORM}.zip
 echo "Downloading tflint from $TFLINT_PATH"
-curl -sLo_ "${TFLINT_PATH}"
+curl --silent --show-error --fail --location -o _ "${TFLINT_PATH}"
 unzip -p _ > "${EXE_FOLDER}/tflint"
 chmod +x "${EXE_FOLDER}/tflint"
 rm _
 
 TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-v${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
 echo "Downloading terraform-docs from $TERRAFORM_DOCS_PATH"
-curl -sLo "${EXE_FOLDER}/terraform-docs" "${TERRAFORM_DOCS_PATH}"
+curl --silent --show-error --fail --location -o "$EXE_FOLDER/terraform-docs" "$TERRAFORM_DOCS_PATH"
 chmod +x "${EXE_FOLDER}/terraform-docs"

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -13,12 +13,12 @@ fi
 
 TFLINT_PATH=https://github.com/terraform-linters/tflint/releases/download/v${TF_LINT_VERSION}/tflint_linux_${PLATFORM}.zip
 echo "Downloading tflint from $TFLINT_PATH"
-curl -sLo_ ${TFLINT_PATH}
-unzip -p _ > ${EXE_FOLDER}/tflint
-chmod +x ${EXE_FOLDER}/tflint
+curl -sLo_ "${TFLINT_PATH}"
+unzip -p _ > "${EXE_FOLDER}"/tflint
+chmod +x "${EXE_FOLDER}"/tflint
 rm _
 
 TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-v${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
 echo "Downloading terraform-docs from $TERRAFORM_DOCS_PATH"
-curl -sLo ${EXE_FOLDER}/terraform-docs ${TERRAFORM_DOCS_PATH}
-chmod +x ${EXE_FOLDER}/terraform-docs
+curl -sLo "${EXE_FOLDER}"/terraform-docs "${TERRAFORM_DOCS_PATH}"
+chmod +x "${EXE_FOLDER}"/terraform-docs

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -xeu
 
 if [ "$TARGETPLATFORM" = linux/arm64 ]
 then

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -16,7 +16,7 @@ unzip -p _ > "${EXE_FOLDER}/tflint"
 chmod +x "${EXE_FOLDER}/tflint"
 rm _
 
-TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-v${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
+TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
 echo "Downloading terraform-docs from $TERRAFORM_DOCS_PATH"
 curl --silent --show-error --fail --location -o "$EXE_FOLDER/terraform-docs" "$TERRAFORM_DOCS_PATH"
 chmod +x "${EXE_FOLDER}/terraform-docs"

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -xeu
 
+download_and_install() {
+  url="$1"
+  dest="$2"
+
+  curl --silent --show-error --fail --location -o out.zip "$url"
+  unzip -p out.zip > "$dest"
+  chmod +x "$dest"
+  rm -rf out.zip
+}
+
 if [ "$TARGETPLATFORM" = linux/arm64 ]; then
   PLATFORM=arm64
   TF_DOCS_PLATFORM=arm64
@@ -11,12 +21,8 @@ fi
 
 TFLINT_PATH=https://github.com/terraform-linters/tflint/releases/download/v${TF_LINT_VERSION}/tflint_linux_${PLATFORM}.zip
 echo "Downloading tflint from $TFLINT_PATH"
-curl --silent --show-error --fail --location -o _ "${TFLINT_PATH}"
-unzip -p _ > "${EXE_FOLDER}/tflint"
-chmod +x "${EXE_FOLDER}/tflint"
-rm _
+download_and_install "$TFLINT_PATH" "$EXE_FOLDER/tflint"
 
-TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
+TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs_${TF_DOC_VERSION}_linux_${TF_DOCS_PLATFORM}.zip
 echo "Downloading terraform-docs from $TERRAFORM_DOCS_PATH"
-curl --silent --show-error --fail --location -o "$EXE_FOLDER/terraform-docs" "$TERRAFORM_DOCS_PATH"
-chmod +x "${EXE_FOLDER}/terraform-docs"
+download_and_install "$TERRAFORM_DOCS_PATH" "$EXE_FOLDER/terraform-docs"

--- a/Dockerfile.1_scripts/download_executables.sh
+++ b/Dockerfile.1_scripts/download_executables.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
-
 set -xeu
 
-if [ "$TARGETPLATFORM" = linux/arm64 ]
-then
+if [ "$TARGETPLATFORM" = linux/arm64 ]; then
   PLATFORM=arm64
   TF_DOCS_PLATFORM=arm64
 else
@@ -14,11 +12,11 @@ fi
 TFLINT_PATH=https://github.com/terraform-linters/tflint/releases/download/v${TF_LINT_VERSION}/tflint_linux_${PLATFORM}.zip
 echo "Downloading tflint from $TFLINT_PATH"
 curl -sLo_ "${TFLINT_PATH}"
-unzip -p _ > "${EXE_FOLDER}"/tflint
-chmod +x "${EXE_FOLDER}"/tflint
+unzip -p _ > "${EXE_FOLDER}/tflint"
+chmod +x "${EXE_FOLDER}/tflint"
 rm _
 
 TERRAFORM_DOCS_PATH=https://github.com/coveord/terraform-docs/releases/download/v${TF_DOC_VERSION}/terraform-docs-v${TF_DOC_VERSION}-linux-${TF_DOCS_PLATFORM}
 echo "Downloading terraform-docs from $TERRAFORM_DOCS_PATH"
-curl -sLo "${EXE_FOLDER}"/terraform-docs "${TERRAFORM_DOCS_PATH}"
-chmod +x "${EXE_FOLDER}"/terraform-docs
+curl -sLo "${EXE_FOLDER}/terraform-docs" "${TERRAFORM_DOCS_PATH}"
+chmod +x "${EXE_FOLDER}/terraform-docs"

--- a/Dockerfile.2_scripts/download_executables.sh
+++ b/Dockerfile.2_scripts/download_executables.sh
@@ -8,7 +8,8 @@ else
 fi
 
 # Install kubectl
-curl -sLo_ "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETPLATFORM}/kubectl"
+curl --silent --show-error --fail --location -o _ \
+  "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETPLATFORM}/kubectl"
 mv _ "${EXE_FOLDER}/kubectl"
 chmod +x "${EXE_FOLDER}/kubectl"
 mkdir -p /home/tgf/.kube
@@ -16,7 +17,8 @@ touch "${KUBECONFIG}"
 chmod 666 "${KUBECONFIG}"
 
 # Install helm (git is also required by helm)
-curl -sL "https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_PLATFORM}.tar.gz" | tar xzo
+curl --silent --show-error --fail --location "https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_PLATFORM}.tar.gz" \
+  | tar xzo
 mv ./${HELM_PLATFORM}/helm "${EXE_FOLDER}/helm"
 rm -rf ./${HELM_PLATFORM}
 chmod +x "$EXE_FOLDER/helm"

--- a/Dockerfile.2_scripts/download_executables.sh
+++ b/Dockerfile.2_scripts/download_executables.sh
@@ -10,15 +10,15 @@ else
 fi
 
 # Install kubectl
-curl -sLo_ https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETPLATFORM}/kubectl && \
-    mv _ ${EXE_FOLDER}/kubectl && \
-    chmod +x ${EXE_FOLDER}/kubectl && \
+curl -sLo_ https://storage.googleapis.com/kubernetes-release/release/v"${KUBE_VERSION}"/bin/"${TARGETPLATFORM}"/kubectl && \
+    mv _ "${EXE_FOLDER}"/kubectl && \
+    chmod +x "${EXE_FOLDER}"/kubectl && \
     mkdir -p /home/tgf/.kube && \
-    touch ${KUBECONFIG} && \
-    chmod 666 ${KUBECONFIG}
+    touch "${KUBECONFIG}" && \
+    chmod 666 "${KUBECONFIG}"
 
 # Install helm (git is also required by helm)
-curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_PLATFORM}.tar.gz | tar xzo && \
-    mv ./${HELM_PLATFORM}/helm ${EXE_FOLDER}/helm && \
+curl -sL https://get.helm.sh/helm-v"${HELM_VERSION}"-${HELM_PLATFORM}.tar.gz | tar xzo && \
+    mv ./${HELM_PLATFORM}/helm "${EXE_FOLDER}"/helm && \
     rm -rf ./${HELM_PLATFORM} && \
-    chmod +x $EXE_FOLDER/helm
+    chmod +x "$EXE_FOLDER"/helm

--- a/Dockerfile.2_scripts/download_executables.sh
+++ b/Dockerfile.2_scripts/download_executables.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -x
+set -xeu
 
 if [ "$TARGETPLATFORM" = linux/arm64 ]
 then

--- a/Dockerfile.2_scripts/download_executables.sh
+++ b/Dockerfile.2_scripts/download_executables.sh
@@ -1,24 +1,22 @@
 #!/bin/sh
-
 set -xeu
 
-if [ "$TARGETPLATFORM" = linux/arm64 ]
-then
+if [ "$TARGETPLATFORM" = linux/arm64 ]; then
   HELM_PLATFORM=linux-arm64
 else
   HELM_PLATFORM=linux-amd64
 fi
 
 # Install kubectl
-curl -sLo_ https://storage.googleapis.com/kubernetes-release/release/v"${KUBE_VERSION}"/bin/"${TARGETPLATFORM}"/kubectl && \
-    mv _ "${EXE_FOLDER}"/kubectl && \
-    chmod +x "${EXE_FOLDER}"/kubectl && \
-    mkdir -p /home/tgf/.kube && \
-    touch "${KUBECONFIG}" && \
-    chmod 666 "${KUBECONFIG}"
+curl -sLo_ "https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETPLATFORM}/kubectl"
+mv _ "${EXE_FOLDER}/kubectl"
+chmod +x "${EXE_FOLDER}/kubectl"
+mkdir -p /home/tgf/.kube
+touch "${KUBECONFIG}"
+chmod 666 "${KUBECONFIG}"
 
 # Install helm (git is also required by helm)
-curl -sL https://get.helm.sh/helm-v"${HELM_VERSION}"-${HELM_PLATFORM}.tar.gz | tar xzo && \
-    mv ./${HELM_PLATFORM}/helm "${EXE_FOLDER}"/helm && \
-    rm -rf ./${HELM_PLATFORM} && \
-    chmod +x "$EXE_FOLDER"/helm
+curl -sL "https://get.helm.sh/helm-v${HELM_VERSION}-${HELM_PLATFORM}.tar.gz" | tar xzo
+mv ./${HELM_PLATFORM}/helm "${EXE_FOLDER}/helm"
+rm -rf ./${HELM_PLATFORM}
+chmod +x "$EXE_FOLDER/helm"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-docker:
-	bash make_dockers.sh


### PR DESCRIPTION
Right now, `terraform-doc` is broken in the image. This is because it failed to download but never crashed.

This PR also includes:

- Shellcheck now validates the shell scripts in this project 🎉 
- We can now build images from the CI for a PR