### PR TITLE
Use `github.ref_type` to detect if we're in a tag in image build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         run: python ./build_and_push_images.py --version "v0.0.PR-$PR_NUMBER"
 
       - name: Build and push release images
-        if: ${{ github.event_name == 'tag' }}
+        if: ${{ github.ref_type == 'tag' }}
         env:
           VERSION: ${{ github.ref_name }}
         run: python ./build_and_push_images.py --version "$VERSION"


### PR DESCRIPTION
Originally, I thought that `${{ github.event_name }}` could be `tag` but that doesn't work in this context. Checking if we're running on a tag is done through `github.ref_type` so we're using that.