### PR TITLE
Update to gotemplate v3.7.2 and terragrunt v2.7.3

### DIFF
--- a/Dockerfile.0.Base
+++ b/Dockerfile.0.Base
@@ -24,8 +24,8 @@ RUN apk upgrade --no-cache && \
 
 # Update version here (do not move at the beginning of the file since it would slow down the docker build)
 ENV TERRAFORM_VERSION="1.0.2"
-ENV TERRAGRUNT_VERSION="2.7.2"
-ENV GOTEMPLATE_VERSION="3.7.1"
+ENV TERRAGRUNT_VERSION="2.7.3"
+ENV GOTEMPLATE_VERSION="3.7.2"
 
 COPY Dockerfile.0_scripts/download_executables.sh .
 RUN chmod +x ./download_executables.sh


### PR DESCRIPTION
Until terragrunt 2.7.3 is released nothing here will work

Unrelated note: the gotemplate and terragrunt versions are mirrored 🪞 