### PR TITLE
Bump Terragrunt to 2.7.4

### DIFF
--- a/Dockerfile.0.Base
+++ b/Dockerfile.0.Base
@@ -24,7 +24,7 @@ RUN apk upgrade --no-cache && \
 
 # Update version here (do not move at the beginning of the file since it would slow down the docker build)
 ENV TERRAFORM_VERSION="1.0.2"
-ENV TERRAGRUNT_VERSION="2.7.3"
+ENV TERRAGRUNT_VERSION="2.7.4"
 ENV GOTEMPLATE_VERSION="3.7.2"
 
 COPY Dockerfile.0_scripts/download_executables.sh .


### PR DESCRIPTION
Notable changes are performance savings in *-all commands and better "no changes" detection